### PR TITLE
Add code-block, markdown, and message components

### DIFF
--- a/app/docs/code-block/code-block-basic.tsx
+++ b/app/docs/code-block/code-block-basic.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { CodeBlock, CodeBlockCode } from "@/components/prompt-kit/code-block"
+
+export function CodeBlockBasic() {
+  const code = `function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+
+// Call the function
+greet("World");`
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockCode code={code} language="javascript" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/code-block-css.tsx
+++ b/app/docs/code-block/code-block-css.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { CodeBlock, CodeBlockCode } from "@/components/prompt-kit/code-block"
+
+export function CodeBlockCSS() {
+  const code = `.button {
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  padding: 15px 32px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.button:hover {
+  background-color: #45a049;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}`
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockCode code={code} language="css" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/code-block-nord.tsx
+++ b/app/docs/code-block/code-block-nord.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import {
+  CodeBlock,
+  CodeBlockCode,
+  CodeBlockGroup,
+} from "@/components/prompt-kit/code-block"
+import { Button } from "@/components/ui/button"
+import { Check, Copy } from "lucide-react"
+import { useState } from "react"
+
+export function CodeBlockNord() {
+  const [copied, setCopied] = useState(false)
+
+  const code = `function calculateTotal(items) {
+  return items
+    .filter(item => item.price > 0)
+    .reduce((total, item) => {
+      return total + item.price * item.quantity;
+    }, 0);
+}`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockGroup className="border-border border-b px-4 py-2">
+          <div className="flex items-center gap-2">
+            <div className="bg-primary/10 text-primary rounded px-2 py-1 text-xs font-medium">
+              JavaScript
+            </div>
+            <span className="text-muted-foreground text-sm">Nord Theme</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </CodeBlockGroup>
+        <CodeBlockCode code={code} language="javascript" theme="nord" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/code-block-python.tsx
+++ b/app/docs/code-block/code-block-python.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { CodeBlock, CodeBlockCode } from "@/components/prompt-kit/code-block"
+
+export function CodeBlockPython() {
+  const code = `def fibonacci(n):
+    a, b = 0, 1
+    for _ in range(n):
+        yield a
+        a, b = b, a + b
+
+# Generate the first 10 Fibonacci numbers
+for number in fibonacci(10):
+    print(number)`
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockCode code={code} language="python" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/code-block-themed.tsx
+++ b/app/docs/code-block/code-block-themed.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import {
+  CodeBlock,
+  CodeBlockCode,
+  CodeBlockGroup,
+} from "@/components/prompt-kit/code-block"
+import { Button } from "@/components/ui/button"
+import { Check, Copy } from "lucide-react"
+import { useState } from "react"
+
+export function CodeBlockThemed() {
+  const [copied, setCopied] = useState(false)
+
+  const code = `function calculateTotal(items) {
+  return items
+    .filter(item => item.price > 0)
+    .reduce((total, item) => {
+      return total + item.price * item.quantity;
+    }, 0);
+}`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockGroup className="border-border border-b px-4 py-2">
+          <div className="flex items-center gap-2">
+            <div className="bg-primary/10 text-primary rounded px-2 py-1 text-xs font-medium">
+              JavaScript
+            </div>
+            <span className="text-muted-foreground text-sm">
+              GitHub Dark Theme
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </CodeBlockGroup>
+        <CodeBlockCode code={code} language="javascript" theme="github-dark" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/code-block-with-header.tsx
+++ b/app/docs/code-block/code-block-with-header.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import {
+  CodeBlock,
+  CodeBlockCode,
+  CodeBlockGroup,
+} from "@/components/prompt-kit/code-block"
+import { Button } from "@/components/ui/button"
+import { Check, Copy } from "lucide-react"
+import { useState } from "react"
+
+export function CodeBlockWithHeader() {
+  const [copied, setCopied] = useState(false)
+
+  const code = `import { useState } from 'react';
+
+function Counter() {
+  const [count, setCount] = useState(0);
+  
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button onClick={() => setCount(count + 1)}>
+        Click me
+      </button>
+    </div>
+  );
+}`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full max-w-3xl">
+      <CodeBlock>
+        <CodeBlockGroup className="border-border border-b py-2 pr-2 pl-4">
+          <div className="flex items-center gap-2">
+            <div className="bg-primary/10 text-primary rounded px-2 py-1 text-xs font-medium">
+              React
+            </div>
+            <span className="text-muted-foreground text-sm">counter.tsx</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </CodeBlockGroup>
+        <CodeBlockCode code={code} language="tsx" />
+      </CodeBlock>
+    </div>
+  )
+}

--- a/app/docs/code-block/page.mdx
+++ b/app/docs/code-block/page.mdx
@@ -1,0 +1,193 @@
+import ComponentCodePreview from "@/components/app/component-code-preview"
+import { CodeBlockBasic } from "./code-block-basic"
+import { CodeBlockCSS } from "./code-block-css"
+import { CodeBlockNord } from "./code-block-nord"
+import { CodeBlockPython } from "./code-block-python"
+import { CodeBlockThemed } from "./code-block-themed"
+import { CodeBlockWithHeader } from "./code-block-with-header"
+
+# Code Block
+
+A component for displaying code snippets with syntax highlighting and customizable styling.
+
+## Examples
+
+### Basic Code Block
+
+<ComponentCodePreview
+  component={<CodeBlockBasic />}
+  filePath="app/docs/code-block/code-block-basic.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+### Code Block with Header
+
+You can use `CodeBlockGroup` to add a header with metadata and actions to your code blocks.
+
+<ComponentCodePreview
+  component={<CodeBlockWithHeader />}
+  filePath="app/docs/code-block/code-block-with-header.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+### Different Languages
+
+You can highlight code in various languages by changing the `language` prop.
+
+#### Python Example
+
+<ComponentCodePreview
+  component={<CodeBlockPython />}
+  filePath="app/docs/code-block/code-block-python.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+#### CSS Example
+
+<ComponentCodePreview
+  component={<CodeBlockCSS />}
+  filePath="app/docs/code-block/code-block-css.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+### Different Themes
+
+Shiki supports many popular themes. Here are some examples:
+
+#### GitHub Dark Theme
+
+<ComponentCodePreview
+  component={<CodeBlockThemed />}
+  filePath="app/docs/code-block/code-block-themed.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+#### Nord Theme
+
+<ComponentCodePreview
+  component={<CodeBlockNord />}
+  filePath="app/docs/code-block/code-block-nord.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+
+<TabsContent value="cli">
+
+<CodeBlock
+  code={`npx shadcn add "https://prompt-kit.com/c/code-block.json"`}
+  language="bash"
+/>
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<CodeBlock filePath="components/prompt-kit/code-block.tsx" language="tsx" />
+
+<Step>Install the required dependencies.</Step>
+
+<CodeBlock code={`npm install shiki`} language="bash" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Component API
+
+### CodeBlock
+
+| Prop      | Type                              | Default | Description                |
+| :-------- | :-------------------------------- | :------ | :------------------------- |
+| children  | React.ReactNode                   |         | Child components to render |
+| className | string                            |         | Additional CSS classes     |
+| ...props  | `React.HTMLProps<HTMLDivElement>` |         | All other div props        |
+
+### CodeBlockCode
+
+| Prop      | Type                              | Default        | Description                          |
+| :-------- | :-------------------------------- | :------------- | :----------------------------------- |
+| code      | string                            |                | The code to display and highlight    |
+| language  | string                            | "tsx"          | The language for syntax highlighting |
+| theme     | string                            | "github-light" | The theme for syntax highlighting    |
+| className | string                            |                | Additional CSS classes               |
+| ...props  | `React.HTMLProps<HTMLDivElement>` |                | All other div props                  |
+
+### CodeBlockGroup
+
+| Prop      | Type                                   | Default | Description                |
+| :-------- | :------------------------------------- | :------ | :------------------------- |
+| children  | React.ReactNode                        |         | Child components to render |
+| className | string                                 |         | Additional CSS classes     |
+| ...props  | `React.HTMLAttributes<HTMLDivElement>` |         | All other div props        |
+
+## Usage with Markdown
+
+The `CodeBlock` component is used internally by the `Markdown` component to render code blocks in markdown content. When used within the `Markdown` component, code blocks are automatically wrapped with the `not-prose` class to prevent conflicts with prose styling.
+
+<CodeBlock
+  code={`import { Markdown } from "@/components/prompt-kit/markdown"
+
+function MyComponent() {
+const markdownContent = \` # Example
+
+    \\\`\\\`\\\`javascript
+    function greet(name) {
+
+    return \`Hello, \\\${name}!\\\`;
+    }
+    \\\`\\\`\\\`
+
+    return <Markdown className="prose">{markdownContent}</Markdown>
+
+}`}
+language="tsx"
+/>
+
+## Tailwind Typography and not-prose
+
+The `CodeBlock` component includes the `not-prose` class by default to prevent Tailwind Typography's prose styling from affecting code blocks. This is important when using the [@tailwindcss/typography](https://github.com/tailwindlabs/tailwindcss-typography) plugin, which provides beautiful typography defaults but can interfere with code block styling.
+
+Since code blocks are styled with Shiki for syntax highlighting, they should not inherit Tailwind Typography styles. The `not-prose` class ensures that code blocks maintain their intended appearance regardless of the surrounding typography context.
+
+<CodeBlock
+  code={`<article className="prose">
+  <h1>My Content</h1>
+  <p>This content has prose styling applied.</p>
+  
+  {/* The CodeBlock has not-prose to prevent prose styling */}
+  <CodeBlock>
+    <CodeBlockCode code={code} language="javascript" />
+  </CodeBlock>
+</article>`}
+  language="tsx"
+/>
+
+## Customizing Syntax Highlighting
+
+The `CodeBlockCode` component uses [Shiki](https://shiki.matsu.io/) for syntax highlighting. You can customize the theme by passing a different theme name to the `theme` prop.
+
+Shiki supports many popular themes including:
+
+- github-light (default)
+- github-dark
+- dracula
+- nord
+- and more.
+
+For a complete list of supported themes, refer to the [Shiki documentation](https://github.com/shikijs/shiki/blob/main/docs/themes.md).

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -9,7 +9,7 @@ export default function LayoutDocs({
     <>
       <div
         className={cn(
-          "prose prose-zinc dark:prose-invert prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-12 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h5:scroll-m-20 prose-h6:scroll-m-20 prose-strong:font-medium prose-code:block prose-code:rounded-md prose-code:bg-gray-100 prose-code:p-1 prose-code:text-gray-800 prose-table:block prose-table:overflow-y-auto mr-0 max-w-full min-w-0 flex-1",
+          "prose prose-zinc dark:prose-invert prose-h1:scroll-m-20 prose-h1:text-2xl prose-h1:font-semibold prose-h2:mt-12 prose-h2:scroll-m-20 prose-h2:text-xl prose-h2:font-medium prose-h3:scroll-m-20 prose-h3:text-base prose-h3:font-medium prose-h4:scroll-m-20 prose-h4:text-base prose-h4:font-medium prose-h5:scroll-m-20 prose-h5:text-sm prose-h6:scroll-m-20 prose-h6:text-xs prose-strong:font-medium prose-code:block prose-code:rounded-md prose-code:bg-gray-100 prose-code:p-1 prose-code:text-gray-800 prose-table:block prose-table:overflow-y-auto mr-0 max-w-full min-w-0 flex-1",
           "[&_.ch-code_code]:bg-primary-foreground"
         )}
       >

--- a/app/docs/markdown/markdown-basic.tsx
+++ b/app/docs/markdown/markdown-basic.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { Markdown } from "@/components/prompt-kit/markdown"
+import { cn } from "@/lib/utils"
+
+export function MarkdownBasic() {
+  const markdownContent = `
+# Markdown Example
+
+This is a **bold text** and this is an *italic text*.
+
+## Lists
+
+### Unordered List
+- Item 1
+- Item 2
+- Item 3
+
+### Ordered List
+1. First item
+2. Second item
+3. Third item
+
+## Links and Images
+
+[Visit Prompt Kit](https://prompt-kit.com)
+
+## Code
+
+Inline \`code\` example.
+
+\`\`\`javascript
+// Code block example
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+\`\`\`
+`
+
+  return (
+    <div className="w-full max-w-3xl">
+      <Markdown className="prose prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-h4:text-base prose-h5:text-sm prose-h6:text-xs">
+        {markdownContent}
+      </Markdown>
+    </div>
+  )
+}

--- a/app/docs/markdown/markdown-custom-components.tsx
+++ b/app/docs/markdown/markdown-custom-components.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { Markdown } from "@/components/prompt-kit/markdown"
+import { cn } from "@/lib/utils"
+import { useState } from "react"
+import { Components } from "react-markdown"
+
+export function MarkdownCustomComponents() {
+  const [theme, setTheme] = useState<"light" | "dark">("light")
+
+  const markdownContent = `
+# Custom Components Example
+
+## Styled Headings
+
+### This is a custom styled H3
+
+## Custom Links
+
+[Click me to toggle theme](#)
+
+## Custom Blockquotes
+
+> This is a custom styled blockquote
+> with multiple lines of text.
+
+## Custom Lists
+
+- First item with custom styling
+- Second item with custom styling
+- Third item with custom styling
+`
+
+  const customComponents: Partial<Components> = {
+    h3: ({ children }) => (
+      <h3 className="my-4 text-xl font-bold text-blue-500">{children}</h3>
+    ),
+    a: ({ children, href }) => (
+      <a
+        href={href}
+        className="text-purple-500 underline hover:text-purple-700"
+        onClick={(e) => {
+          e.preventDefault()
+          setTheme((prev) => (prev === "light" ? "dark" : "light"))
+        }}
+      >
+        {children}
+      </a>
+    ),
+    blockquote: ({ children }) => (
+      <blockquote className="my-4 border-l-4 border-green-500 pl-4 italic">
+        {children}
+      </blockquote>
+    ),
+    li: ({ children }) => (
+      <li className="my-1 flex items-center">
+        <span className="mr-2 inline-block h-2 w-2 rounded-full bg-orange-500"></span>
+        <span>{children}</span>
+      </li>
+    ),
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-3xl rounded-lg p-6 transition-colors",
+        theme === "light" ? "bg-white text-black" : "bg-black text-white"
+      )}
+    >
+      <div className="mb-4 flex justify-end">
+        <button
+          onClick={() =>
+            setTheme((prev) => (prev === "light" ? "dark" : "light"))
+          }
+          className={cn(
+            "rounded px-3 py-1 text-sm",
+            theme === "light" ? "bg-gray-200" : "bg-gray-900"
+          )}
+        >
+          Toggle {theme === "light" ? "Dark" : "Light"} Mode
+        </button>
+      </div>
+      <Markdown components={customComponents}>{markdownContent}</Markdown>
+    </div>
+  )
+}

--- a/app/docs/markdown/page.mdx
+++ b/app/docs/markdown/page.mdx
@@ -1,0 +1,132 @@
+import ComponentCodePreview from "@/components/app/component-code-preview"
+import { MarkdownBasic } from "./markdown-basic"
+import { MarkdownCustomComponents } from "./markdown-custom-components"
+
+# Markdown
+
+A component for rendering Markdown content with support for GitHub Flavored Markdown (GFM) and custom component styling.
+
+## Examples
+
+### Basic Markdown
+
+Render basic Markdown with support for bold, italics, lists, code blocks and more.
+
+<ComponentCodePreview
+  component={<MarkdownBasic />}
+  filePath="app/docs/markdown/markdown-basic.tsx"
+  classNameComponentContainer="p-8"
+  disableNotProse
+/>
+
+### Markdown with Custom Components
+
+You can customize how different Markdown elements are rendered by providing custom components.
+
+<ComponentCodePreview
+  component={<MarkdownCustomComponents />}
+  filePath="app/docs/markdown/markdown-custom-components.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+
+<TabsContent value="cli">
+
+<CodeBlock
+  code={`npx shadcn add "https://prompt-kit.com/c/markdown.json"`}
+  language="bash"
+/>
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<CodeBlock filePath="components/prompt-kit/markdown.tsx" language="tsx" />
+
+<Step>Install the required dependencies.</Step>
+
+<CodeBlock code={`npm install react-markdown remark-gfm`} language="bash" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Component API
+
+### Markdown
+
+| Prop       | Type                                         | Default            | Description                                     |
+| :--------- | :------------------------------------------- | :----------------- | :---------------------------------------------- |
+| children   | string                                       |                    | Markdown content to render                      |
+| className  | string                                       |                    | Additional CSS classes                          |
+| components | `Partial<Components>`                        | INITIAL_COMPONENTS | Custom components to override default rendering |
+| ...props   | `React.ComponentProps<typeof ReactMarkdown>` |                    | All other ReactMarkdown props                   |
+
+## Customizing Components
+
+You can customize how different Markdown elements are rendered by providing a `components` prop. This is an object where keys are HTML element names and values are React components.
+
+<CodeBlock code={`const customComponents = {
+    h1: ({ children }) => <h1 className="text-2xl font-bold text-blue-500">{children}</h1>,
+    a: ({ href, children }) => <a href={href} className="text-purple-500 underline">{children}</a>,
+    // ... other components
+}
+
+<Markdown components={customComponents}>{markdownContent}</Markdown>
+`} language="tsx" />
+
+## Supported Markdown Features
+
+The Markdown component uses [react-markdown](https://github.com/remarkjs/react-markdown) with [remark-gfm](https://github.com/remarkjs/remark-gfm) to support GitHub Flavored Markdown, which includes:
+
+- Tables
+- Strikethrough
+- Tasklists
+- Literal URLs
+- Footnotes
+
+Additionally, the component includes built-in code block highlighting through the `CodeBlock` component.
+
+## Styling with Tailwind Typography
+
+For the best typography styling experience, we recommend using the [@tailwindcss/typography](https://github.com/tailwindlabs/tailwindcss-typography) plugin. This plugin provides a set of `prose` classes that add beautiful typographic defaults to your markdown content.
+
+<CodeBlock code={`npm install -D @tailwindcss/typography`} language="bash" />
+
+When using the Markdown component with Tailwind Typography, you can apply the `prose` class:
+
+<CodeBlock
+  code={`<Markdown className="prose dark:prose-invert">{markdownContent}</Markdown>`}
+  language="tsx"
+/>
+
+### Handling Code Blocks
+
+As you've seen in our examples, code blocks within prose content can sometimes cause styling conflicts. The Tailwind Typography plugin provides a `not-prose` class to exclude elements from prose styling:
+
+<CodeBlock code={`<article className="prose">
+    <h1>My Content</h1>
+    <p>Regular content with prose styling...</p>
+
+    <div className="not-prose">
+      <!-- Code blocks or other elements that shouldn't inherit prose styles -->
+    </div>
+
+</article>
+`} language="tsx" />

--- a/app/docs/message/message-basic.tsx
+++ b/app/docs/message/message-basic.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import {
+  Message,
+  MessageAvatar,
+  MessageContent,
+} from "@/components/prompt-kit/message"
+
+export function MessageBasic() {
+  return (
+    <div className="flex flex-col gap-8">
+      <Message className="justify-end">
+        <MessageContent>Hello! How can I help you today?</MessageContent>
+      </Message>
+
+      <Message className="justify-start">
+        <MessageAvatar src="/avatars/ai.png" alt="AI" fallback="AI" />
+        <MessageContent markdown className="bg-transparent p-0">
+          I can help with a variety of tasks: - Answering questions - Providing
+          information - Assisting with coding - Generating creative content What
+          would you like help with today?
+        </MessageContent>
+      </Message>
+    </div>
+  )
+}

--- a/app/docs/message/message-with-actions.tsx
+++ b/app/docs/message/message-with-actions.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import {
+  Message,
+  MessageAction,
+  MessageActions,
+  MessageAvatar,
+  MessageContent,
+} from "@/components/prompt-kit/message"
+import { Button } from "@/components/ui/button"
+import { Copy, ThumbsDown, ThumbsUp } from "lucide-react"
+import { useState } from "react"
+
+export function MessageWithActions() {
+  const [liked, setLiked] = useState<boolean | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = () => {
+    const text =
+      "I can help with a variety of tasks:\n\n- Answering questions\n- Providing information\n- Assisting with coding\n- Generating creative content\n\nWhat would you like help with today?"
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <Message className="justify-end">
+        <MessageContent>Hello! How can I help you today?</MessageContent>
+      </Message>
+
+      <Message className="justify-start">
+        <MessageAvatar src="/avatars/ai.png" alt="AI" fallback="AI" />
+        <div className="flex w-full flex-col gap-2">
+          <MessageContent markdown className="bg-transparent p-0">
+            I can help with a variety of tasks: - Answering questions -
+            Providing information - Assisting with coding - Generating creative
+            content What would you like help with today?
+          </MessageContent>
+
+          <MessageActions className="self-end">
+            <MessageAction tooltip="Copy to clipboard">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 rounded-full"
+                onClick={handleCopy}
+              >
+                <Copy className={`size-4 ${copied ? "text-green-500" : ""}`} />
+              </Button>
+            </MessageAction>
+
+            <MessageAction tooltip="Helpful">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`h-8 w-8 rounded-full ${liked === true ? "bg-green-100 text-green-500" : ""}`}
+                onClick={() => setLiked(true)}
+              >
+                <ThumbsUp className="size-4" />
+              </Button>
+            </MessageAction>
+
+            <MessageAction tooltip="Not helpful">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`h-8 w-8 rounded-full ${liked === false ? "bg-red-100 text-red-500" : ""}`}
+                onClick={() => setLiked(false)}
+              >
+                <ThumbsDown className="size-4" />
+              </Button>
+            </MessageAction>
+          </MessageActions>
+        </div>
+      </Message>
+    </div>
+  )
+}

--- a/app/docs/message/page.mdx
+++ b/app/docs/message/page.mdx
@@ -1,0 +1,108 @@
+import ComponentCodePreview from "@/components/app/component-code-preview"
+import { MessageBasic } from "./message-basic"
+import { MessageWithActions } from "./message-with-actions"
+
+# Message
+
+A component for displaying messages in a conversation interface, with support for avatars, markdown content, and interactive actions.
+
+## Examples
+
+### Basic Message
+
+<ComponentCodePreview
+  component={<MessageBasic />}
+  filePath="app/docs/message/message-basic.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+### Message with Actions
+
+You can use `MessageActions` and `MessageAction` to add interactive elements to your messages.
+
+<ComponentCodePreview
+  component={<MessageWithActions />}
+  filePath="app/docs/message/message-with-actions.tsx"
+  classNameComponentContainer="p-8"
+/>
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+
+<TabsContent value="cli">
+
+<CodeBlock
+  code={`npx shadcn add "https://prompt-kit.com/c/message.json"`}
+  language="bash"
+/>
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<CodeBlock filePath="components/prompt-kit/message.tsx" language="tsx" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Component API
+
+### Message
+
+| Prop      | Type                              | Default | Description                |
+| :-------- | :-------------------------------- | :------ | :------------------------- |
+| children  | React.ReactNode                   |         | Child components to render |
+| className | string                            |         | Additional CSS classes     |
+| ...props  | `React.HTMLProps<HTMLDivElement>` |         | All other div props        |
+
+### MessageAvatar
+
+| Prop      | Type   | Default | Description                            |
+| :-------- | :----- | :------ | :------------------------------------- |
+| src       | string |         | URL of the avatar image                |
+| alt       | string |         | Alt text for the avatar image          |
+| fallback  | string |         | Text to display if image fails to load |
+| delayMs   | number |         | Delay before showing fallback (in ms)  |
+| className | string |         | Additional CSS classes                 |
+
+### MessageContent
+
+| Prop      | Type                              | Default | Description                           |
+| :-------- | :-------------------------------- | :------ | :------------------------------------ |
+| children  | React.ReactNode                   |         | Content to display in the message     |
+| markdown  | boolean                           | false   | Whether to render content as markdown |
+| className | string                            |         | Additional CSS classes                |
+| ...props  | `React.HTMLProps<HTMLDivElement>` |         | All other div props                   |
+
+### MessageActions
+
+| Prop      | Type                              | Default | Description                |
+| :-------- | :-------------------------------- | :------ | :------------------------- |
+| children  | React.ReactNode                   |         | Child components to render |
+| className | string                            |         | Additional CSS classes     |
+| ...props  | `React.HTMLProps<HTMLDivElement>` |         | All other div props        |
+
+### MessageAction
+
+| Prop      | Type                                   | Default | Description                                     |
+| :-------- | :------------------------------------- | :------ | :---------------------------------------------- |
+| tooltip   | React.ReactNode                        |         | Content to show in the tooltip                  |
+| children  | React.ReactNode                        |         | Child component to trigger the tooltip          |
+| className | string                                 |         | Additional CSS classes for the tooltip          |
+| side      | "top" \| "bottom" \| "left" \| "right" | "top"   | Position of the tooltip relative to the trigger |
+| ...props  | `React.ComponentProps<typeof Tooltip>` |         | All other Tooltip component props               |

--- a/app/layout.client.tsx
+++ b/app/layout.client.tsx
@@ -33,6 +33,18 @@ const componentsMenuItems = [
     title: "Prompt Input",
     url: "/docs/prompt-input",
   },
+  {
+    title: "Message",
+    url: "/docs/message",
+  },
+  {
+    title: "Markdown",
+    url: "/docs/markdown",
+  },
+  {
+    title: "Code Block",
+    url: "/docs/code-block",
+  },
 ]
 
 const socialMenuItems = [

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,7 +142,7 @@ export default function Home() {
           </AnimatedBackground>
         </div>
       </div>
-      <CodeBlock className="relative mb-20 rounded" language="tsx">
+      <CodeBlock className="relative mb-20 rounded">
         <CodeBlockGroup className="absolute top-4 right-4">
           <button
             onClick={onCopy}
@@ -151,7 +151,7 @@ export default function Home() {
             <TextMorph>{hasCopyLabel ? "Copied" : "Copy"}</TextMorph>
           </button>
         </CodeBlockGroup>
-        <CodeBlockCode code={CODE_SAMPLE} />
+        <CodeBlockCode code={CODE_SAMPLE} language="tsx" />
       </CodeBlock>
     </>
   )

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -25,6 +25,21 @@ export const routes: Route[] = [
     label: "Prompt Input",
     order: 3,
   },
+  {
+    path: "/docs/message",
+    label: "Message",
+    order: 4,
+  },
+  {
+    path: "/docs/markdown",
+    label: "Markdown",
+    order: 5,
+  },
+  {
+    path: "/docs/code-block",
+    label: "Code Block",
+    order: 6,
+  },
 ]
 
 export function getNavigation(currentPath: string) {

--- a/components/app/code-preview.tsx
+++ b/components/app/code-preview.tsx
@@ -41,7 +41,7 @@ export default function CodePreview({ code, children }: CodePreviewProps) {
           <Check className="h-4 w-4 text-zinc-400" />
         </div>
       </div>
-      <div className="max-h-[650px] overflow-auto overflow-x-auto p-4 text-[13px]">
+      <div className="not-prose max-h-[650px] overflow-auto overflow-x-auto p-4 text-[13px]">
         {children}
       </div>
     </div>

--- a/components/app/component-code-preview.tsx
+++ b/components/app/component-code-preview.tsx
@@ -1,4 +1,5 @@
 import { extractCodeFromFilePath } from "@/lib/code"
+import { cn } from "@/lib/utils"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs"
 import CodePreview from "./code-preview"
 import { CodeRenderer } from "./code-renderer"
@@ -9,6 +10,8 @@ type ComponentCodePreview = {
   filePath: string
   hasReTrigger?: boolean
   classNameComponentContainer?: string
+  classNameContainer?: string
+  disableNotProse?: boolean
 }
 
 export default function ComponentCodePreview({
@@ -16,11 +19,19 @@ export default function ComponentCodePreview({
   filePath,
   hasReTrigger,
   classNameComponentContainer,
+  classNameContainer,
+  disableNotProse = false,
 }: ComponentCodePreview) {
   const fileContent = extractCodeFromFilePath(filePath)
 
   return (
-    <div className="not-prose relative z-0 flex items-center justify-between pb-3">
+    <div
+      className={cn(
+        !disableNotProse && "not-prose",
+        "relative z-0 flex items-center justify-between pb-3",
+        classNameContainer
+      )}
+    >
       <Tabs defaultValue="preview" className="relative mr-auto w-full">
         <TabsList>
           <TabsTrigger value="preview">Preview</TabsTrigger>

--- a/components/prompt-kit/code-block.tsx
+++ b/components/prompt-kit/code-block.tsx
@@ -1,130 +1,89 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import React, { createContext, useContext, useEffect, useState } from "react"
-import { CodeToHastOptions, codeToHtml, type ShikiTransformer } from "shiki"
+import React, { useEffect, useState } from "react"
+import { codeToHtml } from "shiki"
 
-type CodeBlockContextType = {
-  language: string
-  theme?: string
-  transformers?: ShikiTransformer[]
-  options?: CodeToHastOptions
-}
-const CodeBlockContext = createContext<CodeBlockContextType | undefined>(
-  undefined
-)
-function useCodeBlock() {
-  const context = useContext(CodeBlockContext)
-  if (!context) {
-    throw new Error("useCodeBlock must be used within a CodeBlock")
-  }
-  return context
-}
-async function highlightCode(
-  code: string,
-  lang: string,
-  theme?: string,
-  transformers?: ShikiTransformer[],
-  options?: CodeToHastOptions
-) {
-  return await codeToHtml(code, {
-    lang,
-    theme: theme || "github-light",
-    transformers,
-    ...options,
-  })
-}
-type CodeBlockProps = {
-  language?: string
-  theme?: string
-  transformers?: ShikiTransformer[]
-  options?: CodeToHastOptions
-  children: React.ReactNode
+export type CodeBlockProps = {
+  children?: React.ReactNode
   className?: string
-}
-function CodeBlock({
-  language = "tsx",
-  theme,
-  transformers,
-  options,
-  children,
-  className,
-}: CodeBlockProps) {
+} & React.HTMLProps<HTMLDivElement>
+
+function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   return (
-    <CodeBlockContext.Provider
-      value={{ language, theme, transformers, options }}
+    <div
+      className={cn(
+        "not-prose flex w-full flex-col border",
+        "border-border bg-card text-card-foreground rounded-xl",
+        className
+      )}
+      {...props}
     >
-      <div
-        className={cn(
-          "not-prose flex w-full flex-col gap-2 border p-4 text-sm",
-          "border-border bg-card text-card-foreground rounded",
-          className
-        )}
-      >
-        {children}
-      </div>
-    </CodeBlockContext.Provider>
+      {children}
+    </div>
   )
 }
-type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>
+
+export type CodeBlockCodeProps = {
+  code: string
+  language?: string
+  theme?: string
+  className?: string
+} & React.HTMLProps<HTMLDivElement>
+
+function CodeBlockCode({
+  code,
+  language = "tsx",
+  theme = "github-light",
+  className,
+  ...props
+}: CodeBlockCodeProps) {
+  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function highlight() {
+      const html = await codeToHtml(code, { lang: language, theme })
+      setHighlightedHtml(html)
+    }
+    highlight()
+  }, [code, language, theme])
+
+  const classNames = cn(
+    "w-full overflow-x-auto text-[13px] [&>pre]:px-4 py-4",
+    className
+  )
+
+  // SSR fallback: render plain code if not hydrated yet
+  return highlightedHtml ? (
+    <div
+      className={classNames}
+      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+      {...props}
+    />
+  ) : (
+    <div className={classNames} {...props}>
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}
+
+export type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>
+
 function CodeBlockGroup({
   children,
   className,
   ...props
 }: CodeBlockGroupProps) {
   return (
-    <div className={cn("flex items-center gap-2", className)} {...props}>
+    <div
+      className={cn("flex items-center justify-between", className)}
+      {...props}
+    >
       {children}
     </div>
   )
 }
-type CodeBlockCodeProps = {
-  code: string
-  className?: string
-}
-function CodeBlockCode({ code, className, ...props }: CodeBlockCodeProps) {
-  const { language, theme, transformers, options } = useCodeBlock()
-  const [highlightedHtml, setHighlightedHtml] = useState<string>("")
-  useEffect(() => {
-    async function highlight() {
-      const highlighted = await highlightCode(
-        code,
-        language,
-        theme,
-        transformers,
-        options
-      )
-      setHighlightedHtml(highlighted)
-    }
-    highlight()
-  }, [code, language, theme, transformers, options])
-  return (
-    <div
-      className={cn("w-full overflow-x-auto", className)}
-      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-      {...props}
-    />
-  )
-}
-async function ServerCodeBlockCode({
-  code,
-  className,
-  ...props
-}: CodeBlockCodeProps) {
-  const { language, theme, transformers, options } = useCodeBlock()
-  const highlightedHtml = await highlightCode(
-    code,
-    language,
-    theme,
-    transformers,
-    options
-  )
-  return (
-    <div
-      className={cn("w-full overflow-x-auto", className)}
-      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-      {...props}
-    />
-  )
-}
-export { CodeBlock, CodeBlockGroup, CodeBlockCode, ServerCodeBlockCode }
+
+export { CodeBlockGroup, CodeBlockCode, CodeBlock }

--- a/components/prompt-kit/code-block.tsx
+++ b/components/prompt-kit/code-block.tsx
@@ -13,7 +13,7 @@ function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   return (
     <div
       className={cn(
-        "not-prose flex w-full flex-col border",
+        "not-prose flex w-full flex-col overflow-clip border",
         "border-border bg-card text-card-foreground rounded-xl",
         className
       )}
@@ -49,7 +49,7 @@ function CodeBlockCode({
   }, [code, language, theme])
 
   const classNames = cn(
-    "w-full overflow-x-auto text-[13px] [&>pre]:px-4 py-4",
+    "w-full overflow-x-auto text-[13px] [&>pre]:px-4 [&>pre]:py-4",
     className
   )
 

--- a/components/prompt-kit/markdown.tsx
+++ b/components/prompt-kit/markdown.tsx
@@ -6,7 +6,7 @@ export type MarkdownProps = {
   children: string
   className?: string
   components?: Components
-}
+} & React.ComponentProps<typeof ReactMarkdown>
 
 const extractLanguage = (className?: string) => {
   if (!className) return "plaintext"
@@ -17,20 +17,20 @@ const extractLanguage = (className?: string) => {
 const INITIAL_COMPONENTS: Partial<Components> = {
   code: ({ ...props }) => {
     const language = extractLanguage(props.className)
-
     return (
-      <CodeBlock {...props} language={language}>
-        <CodeBlockCode code={props.children as string} />
+      <CodeBlock className={props.className}>
+        <CodeBlockCode code={props.children as string} language={language} />
       </CodeBlock>
     )
   },
-  pre: ({ children }) => <div className="not-prose">{children}</div>,
+  pre: ({ children }) => <>{children}</>,
 }
 
 export function Markdown({
   children,
   className,
   components = INITIAL_COMPONENTS,
+  ...props
 }: MarkdownProps) {
   return (
     <ReactMarkdown

--- a/components/prompt-kit/markdown.tsx
+++ b/components/prompt-kit/markdown.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils"
 import ReactMarkdown, { Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { CodeBlock, CodeBlockCode } from "./code-block"
@@ -15,11 +16,30 @@ const extractLanguage = (className?: string) => {
 }
 
 const INITIAL_COMPONENTS: Partial<Components> = {
-  code: ({ ...props }) => {
-    const language = extractLanguage(props.className)
+  code: ({ className, children, ...props }: any) => {
+    const isInline =
+      !props.node?.position?.start.line ||
+      props.node?.position?.start.line === props.node?.position?.end.line
+
+    if (isInline) {
+      return (
+        <span
+          className={cn(
+            "bg-primary-foreground rounded-sm px-1 font-mono text-sm",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </span>
+      )
+    }
+
+    const language = extractLanguage(className)
+
     return (
-      <CodeBlock className={props.className}>
-        <CodeBlockCode code={props.children as string} language={language} />
+      <CodeBlock className={className}>
+        <CodeBlockCode code={children as string} language={language} />
       </CodeBlock>
     )
   },
@@ -37,6 +57,7 @@ export function Markdown({
       remarkPlugins={[remarkGfm]}
       components={components}
       className={className}
+      {...props}
     >
       {children}
     </ReactMarkdown>

--- a/components/prompt-kit/message.tsx
+++ b/components/prompt-kit/message.tsx
@@ -1,62 +1,122 @@
 "use client"
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import React from "react"
 import { Markdown } from "./markdown"
 
 export type MessageProps = {
   children: React.ReactNode
   className?: string
+} & React.HTMLProps<HTMLDivElement>
+
+const Message = ({ children, className, ...props }: MessageProps) => (
+  <div className={cn("flex gap-3", className)} {...props}>
+    {children}
+  </div>
+)
+
+export type MessageAvatarProps = {
+  src: string
+  alt: string
+  fallback?: string
+  delayMs?: number
+  className?: string
 }
 
-type MessageContentProps = {
+const MessageAvatar = ({
+  src,
+  alt,
+  fallback,
+  delayMs,
+  className,
+}: MessageAvatarProps) => {
+  return (
+    <Avatar className={cn("h-8 w-8 shrink-0", className)}>
+      <AvatarImage src={src} alt={alt} />
+      {fallback && (
+        <AvatarFallback delayMs={delayMs}>{fallback}</AvatarFallback>
+      )}
+    </Avatar>
+  )
+}
+
+export type MessageContentProps = {
   children: React.ReactNode
   markdown?: boolean
   className?: string
-}
-
-type MessageActionsProps = {
-  children: React.ReactNode
-  className?: string
-}
-
-const Message = ({ children, className }: MessageProps) => (
-  <div className={cn("flex gap-3", className)}>{children}</div>
-)
-
-const MessageAvatar = ({
-  children,
-  className,
-}: {
-  children: React.ReactNode
-  className?: string
-}) => <div className={cn("shrink-0", className)}>{children}</div>
+} & React.ComponentProps<typeof Markdown> &
+  React.HTMLProps<HTMLDivElement>
 
 const MessageContent = ({
   children,
   markdown = false,
   className,
+  ...props
 }: MessageContentProps) => {
   const classNames = cn(
-    "rounded-lg p-2 text-foreground",
-    "bg-secondary",
-    "prose break-words whitespace-normal",
+    "rounded-lg p-2 text-foreground bg-secondary prose break-words whitespace-normal",
     className
   )
 
   return markdown ? (
-    <Markdown className={classNames}>{children as string}</Markdown>
+    <Markdown className={classNames} {...props}>
+      {children as string}
+    </Markdown>
   ) : (
-    <div className={classNames}>{children}</div>
+    <div className={classNames} {...props}>
+      {children}
+    </div>
   )
 }
 
-const MessageActions = ({ children, className }: MessageActionsProps) => (
+export type MessageActionsProps = {
+  children: React.ReactNode
+  className?: string
+} & React.HTMLProps<HTMLDivElement>
+
+const MessageActions = ({
+  children,
+  className,
+  ...props
+}: MessageActionsProps) => (
   <div
     className={cn("text-muted-foreground flex items-center gap-2", className)}
+    {...props}
   >
     {children}
   </div>
 )
 
-export { Message, MessageAvatar, MessageContent, MessageActions }
+export type MessageActionProps = {
+  className?: string
+  tooltip: React.ReactNode
+  children: React.ReactNode
+  side?: "top" | "bottom" | "left" | "right"
+} & React.ComponentProps<typeof Tooltip>
+
+const MessageAction = ({
+  tooltip,
+  children,
+  className,
+  side = "top",
+  ...props
+}: MessageActionProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip {...props}>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} className={className}>
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export { Message, MessageAvatar, MessageContent, MessageActions, MessageAction }

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.1.7",
+        "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
@@ -1569,6 +1570,31 @@
       "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
+      "integrity": "sha512-Paen00T4P8L8gd9bNsRMw7Cbaz85oxiv+hzomsRZgFm2byltPFDtfcoqlWJ8GyZlIBWgLssJlzLCnKU0G0302g==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.1.7",
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",

--- a/public/c/code-block.json
+++ b/public/c/code-block.json
@@ -1,0 +1,22 @@
+{
+  "name": "code-block",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "shiki"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "description": "A component for displaying code snippets with syntax highlighting and customizable styling",
+  "files": [
+    {
+      "path": "code-block.tsx",
+      "content": "\"use client\"\n\nimport { cn } from \"@/lib/utils\"\nimport React, { useEffect, useState } from \"react\"\nimport { codeToHtml } from \"shiki\"\n\nexport type CodeBlockProps = {\n  children?: React.ReactNode\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlock({ children, className, ...props }: CodeBlockProps) {\n  return (\n    <div\n      className={cn(\n        \"not-prose flex w-full flex-col overflow-clip border\",\n        \"border-border bg-card text-card-foreground rounded-xl\",\n        className\n      )}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport type CodeBlockCodeProps = {\n  code: string\n  language?: string\n  theme?: string\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlockCode({\n  code,\n  language = \"tsx\",\n  theme = \"github-light\",\n  className,\n  ...props\n}: CodeBlockCodeProps) {\n  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)\n\n  useEffect(() => {\n    async function highlight() {\n      const html = await codeToHtml(code, { lang: language, theme })\n      setHighlightedHtml(html)\n    }\n    highlight()\n  }, [code, language, theme])\n\n  const classNames = cn(\n    \"w-full overflow-x-auto text-[13px] [&>pre]:px-4 [&>pre]:py-4\",\n    className\n  )\n\n  // SSR fallback: render plain code if not hydrated yet\n  return highlightedHtml ? (\n    <div\n      className={classNames}\n      dangerouslySetInnerHTML={{ __html: highlightedHtml }}\n      {...props}\n    />\n  ) : (\n    <div className={classNames} {...props}>\n      <pre>\n        <code>{code}</code>\n      </pre>\n    </div>\n  )\n}\n\nexport type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>\n\nfunction CodeBlockGroup({\n  children,\n  className,\n  ...props\n}: CodeBlockGroupProps) {\n  return (\n    <div\n      className={cn(\"flex items-center justify-between\", className)}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport { CodeBlockGroup, CodeBlockCode, CodeBlock }\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/markdown.json
+++ b/public/c/markdown.json
@@ -1,0 +1,29 @@
+{
+  "name": "markdown",
+  "type": "registry:ui",
+  "registryDependencies": [],
+  "dependencies": [
+    "react-markdown",
+    "remark-gfm",
+    "shiki"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "description": "A component for rendering Markdown content with support for code blocks, GFM, and custom styling",
+  "files": [
+    {
+      "path": "markdown.tsx",
+      "content": "import { cn } from \"@/lib/utils\"\nimport ReactMarkdown, { Components } from \"react-markdown\"\nimport remarkGfm from \"remark-gfm\"\nimport { CodeBlock, CodeBlockCode } from \"./code-block\"\n\nexport type MarkdownProps = {\n  children: string\n  className?: string\n  components?: Components\n} & React.ComponentProps<typeof ReactMarkdown>\n\nconst extractLanguage = (className?: string) => {\n  if (!className) return \"plaintext\"\n  const match = className.match(/language-(\\w+)/)\n  return match ? match[1] : \"plaintext\"\n}\n\nconst INITIAL_COMPONENTS: Partial<Components> = {\n  code: ({ className, children, ...props }: any) => {\n    const isInline =\n      !props.node?.position?.start.line ||\n      props.node?.position?.start.line === props.node?.position?.end.line\n\n    if (isInline) {\n      return (\n        <span\n          className={cn(\n            \"bg-primary-foreground rounded-sm px-1 font-mono text-sm\",\n            className\n          )}\n          {...props}\n        >\n          {children}\n        </span>\n      )\n    }\n\n    const language = extractLanguage(className)\n\n    return (\n      <CodeBlock className={className}>\n        <CodeBlockCode code={children as string} language={language} />\n      </CodeBlock>\n    )\n  },\n  pre: ({ children }) => <>{children}</>,\n}\n\nexport function Markdown({\n  children,\n  className,\n  components = INITIAL_COMPONENTS,\n  ...props\n}: MarkdownProps) {\n  return (\n    <ReactMarkdown\n      remarkPlugins={[remarkGfm]}\n      components={components}\n      className={className}\n      {...props}\n    >\n      {children}\n    </ReactMarkdown>\n  )\n}\n",
+      "type": "registry:ui"
+    },
+    {
+      "path": "code-block.tsx",
+      "content": "\"use client\"\n\nimport { cn } from \"@/lib/utils\"\nimport React, { useEffect, useState } from \"react\"\nimport { codeToHtml } from \"shiki\"\n\nexport type CodeBlockProps = {\n  children?: React.ReactNode\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlock({ children, className, ...props }: CodeBlockProps) {\n  return (\n    <div\n      className={cn(\n        \"not-prose flex w-full flex-col overflow-clip border\",\n        \"border-border bg-card text-card-foreground rounded-xl\",\n        className\n      )}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport type CodeBlockCodeProps = {\n  code: string\n  language?: string\n  theme?: string\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlockCode({\n  code,\n  language = \"tsx\",\n  theme = \"github-light\",\n  className,\n  ...props\n}: CodeBlockCodeProps) {\n  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)\n\n  useEffect(() => {\n    async function highlight() {\n      const html = await codeToHtml(code, { lang: language, theme })\n      setHighlightedHtml(html)\n    }\n    highlight()\n  }, [code, language, theme])\n\n  const classNames = cn(\n    \"w-full overflow-x-auto text-[13px] [&>pre]:px-4 [&>pre]:py-4\",\n    className\n  )\n\n  // SSR fallback: render plain code if not hydrated yet\n  return highlightedHtml ? (\n    <div\n      className={classNames}\n      dangerouslySetInnerHTML={{ __html: highlightedHtml }}\n      {...props}\n    />\n  ) : (\n    <div className={classNames} {...props}>\n      <pre>\n        <code>{code}</code>\n      </pre>\n    </div>\n  )\n}\n\nexport type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>\n\nfunction CodeBlockGroup({\n  children,\n  className,\n  ...props\n}: CodeBlockGroupProps) {\n  return (\n    <div\n      className={cn(\"flex items-center justify-between\", className)}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport { CodeBlockGroup, CodeBlockCode, CodeBlock }\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/public/c/message.json
+++ b/public/c/message.json
@@ -1,0 +1,37 @@
+{
+  "name": "message",
+  "type": "registry:ui",
+  "registryDependencies": [
+    "avatar",
+    "tooltip"
+  ],
+  "dependencies": [
+    "react-markdown",
+    "remark-gfm",
+    "shiki"
+  ],
+  "devDependencies": [],
+  "tailwind": {},
+  "cssVars": {
+    "light": {},
+    "dark": {}
+  },
+  "description": "A component for displaying chat messages with support for avatars, markdown content, and interactive actions",
+  "files": [
+    {
+      "path": "message.tsx",
+      "content": "\"use client\"\n\nimport { Avatar, AvatarFallback, AvatarImage } from \"@/components/ui/avatar\"\nimport {\n  Tooltip,\n  TooltipContent,\n  TooltipProvider,\n  TooltipTrigger,\n} from \"@/components/ui/tooltip\"\nimport { cn } from \"@/lib/utils\"\nimport { Markdown } from \"./markdown\"\n\nexport type MessageProps = {\n  children: React.ReactNode\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nconst Message = ({ children, className, ...props }: MessageProps) => (\n  <div className={cn(\"flex gap-3\", className)} {...props}>\n    {children}\n  </div>\n)\n\nexport type MessageAvatarProps = {\n  src: string\n  alt: string\n  fallback?: string\n  delayMs?: number\n  className?: string\n}\n\nconst MessageAvatar = ({\n  src,\n  alt,\n  fallback,\n  delayMs,\n  className,\n}: MessageAvatarProps) => {\n  return (\n    <Avatar className={cn(\"h-8 w-8 shrink-0\", className)}>\n      <AvatarImage src={src} alt={alt} />\n      {fallback && (\n        <AvatarFallback delayMs={delayMs}>{fallback}</AvatarFallback>\n      )}\n    </Avatar>\n  )\n}\n\nexport type MessageContentProps = {\n  children: React.ReactNode\n  markdown?: boolean\n  className?: string\n} & React.ComponentProps<typeof Markdown> &\n  React.HTMLProps<HTMLDivElement>\n\nconst MessageContent = ({\n  children,\n  markdown = false,\n  className,\n  ...props\n}: MessageContentProps) => {\n  const classNames = cn(\n    \"rounded-lg p-2 text-foreground bg-secondary prose break-words whitespace-normal\",\n    className\n  )\n\n  return markdown ? (\n    <Markdown className={classNames} {...props}>\n      {children as string}\n    </Markdown>\n  ) : (\n    <div className={classNames} {...props}>\n      {children}\n    </div>\n  )\n}\n\nexport type MessageActionsProps = {\n  children: React.ReactNode\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nconst MessageActions = ({\n  children,\n  className,\n  ...props\n}: MessageActionsProps) => (\n  <div\n    className={cn(\"text-muted-foreground flex items-center gap-2\", className)}\n    {...props}\n  >\n    {children}\n  </div>\n)\n\nexport type MessageActionProps = {\n  className?: string\n  tooltip: React.ReactNode\n  children: React.ReactNode\n  side?: \"top\" | \"bottom\" | \"left\" | \"right\"\n} & React.ComponentProps<typeof Tooltip>\n\nconst MessageAction = ({\n  tooltip,\n  children,\n  className,\n  side = \"top\",\n  ...props\n}: MessageActionProps) => {\n  return (\n    <TooltipProvider>\n      <Tooltip {...props}>\n        <TooltipTrigger asChild>{children}</TooltipTrigger>\n        <TooltipContent side={side} className={className}>\n          {tooltip}\n        </TooltipContent>\n      </Tooltip>\n    </TooltipProvider>\n  )\n}\n\nexport { Message, MessageAvatar, MessageContent, MessageActions, MessageAction }\n",
+      "type": "registry:ui"
+    },
+    {
+      "path": "markdown.tsx",
+      "content": "import { cn } from \"@/lib/utils\"\nimport ReactMarkdown, { Components } from \"react-markdown\"\nimport remarkGfm from \"remark-gfm\"\nimport { CodeBlock, CodeBlockCode } from \"./code-block\"\n\nexport type MarkdownProps = {\n  children: string\n  className?: string\n  components?: Components\n} & React.ComponentProps<typeof ReactMarkdown>\n\nconst extractLanguage = (className?: string) => {\n  if (!className) return \"plaintext\"\n  const match = className.match(/language-(\\w+)/)\n  return match ? match[1] : \"plaintext\"\n}\n\nconst INITIAL_COMPONENTS: Partial<Components> = {\n  code: ({ className, children, ...props }: any) => {\n    const isInline =\n      !props.node?.position?.start.line ||\n      props.node?.position?.start.line === props.node?.position?.end.line\n\n    if (isInline) {\n      return (\n        <span\n          className={cn(\n            \"bg-primary-foreground rounded-sm px-1 font-mono text-sm\",\n            className\n          )}\n          {...props}\n        >\n          {children}\n        </span>\n      )\n    }\n\n    const language = extractLanguage(className)\n\n    return (\n      <CodeBlock className={className}>\n        <CodeBlockCode code={children as string} language={language} />\n      </CodeBlock>\n    )\n  },\n  pre: ({ children }) => <>{children}</>,\n}\n\nexport function Markdown({\n  children,\n  className,\n  components = INITIAL_COMPONENTS,\n  ...props\n}: MarkdownProps) {\n  return (\n    <ReactMarkdown\n      remarkPlugins={[remarkGfm]}\n      components={components}\n      className={className}\n      {...props}\n    >\n      {children}\n    </ReactMarkdown>\n  )\n}\n",
+      "type": "registry:ui"
+    },
+    {
+      "path": "code-block.tsx",
+      "content": "\"use client\"\n\nimport { cn } from \"@/lib/utils\"\nimport React, { useEffect, useState } from \"react\"\nimport { codeToHtml } from \"shiki\"\n\nexport type CodeBlockProps = {\n  children?: React.ReactNode\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlock({ children, className, ...props }: CodeBlockProps) {\n  return (\n    <div\n      className={cn(\n        \"not-prose flex w-full flex-col overflow-clip border\",\n        \"border-border bg-card text-card-foreground rounded-xl\",\n        className\n      )}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport type CodeBlockCodeProps = {\n  code: string\n  language?: string\n  theme?: string\n  className?: string\n} & React.HTMLProps<HTMLDivElement>\n\nfunction CodeBlockCode({\n  code,\n  language = \"tsx\",\n  theme = \"github-light\",\n  className,\n  ...props\n}: CodeBlockCodeProps) {\n  const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)\n\n  useEffect(() => {\n    async function highlight() {\n      const html = await codeToHtml(code, { lang: language, theme })\n      setHighlightedHtml(html)\n    }\n    highlight()\n  }, [code, language, theme])\n\n  const classNames = cn(\n    \"w-full overflow-x-auto text-[13px] [&>pre]:px-4 [&>pre]:py-4\",\n    className\n  )\n\n  // SSR fallback: render plain code if not hydrated yet\n  return highlightedHtml ? (\n    <div\n      className={classNames}\n      dangerouslySetInnerHTML={{ __html: highlightedHtml }}\n      {...props}\n    />\n  ) : (\n    <div className={classNames} {...props}>\n      <pre>\n        <code>{code}</code>\n      </pre>\n    </div>\n  )\n}\n\nexport type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>\n\nfunction CodeBlockGroup({\n  children,\n  className,\n  ...props\n}: CodeBlockGroupProps) {\n  return (\n    <div\n      className={cn(\"flex items-center justify-between\", className)}\n      {...props}\n    >\n      {children}\n    </div>\n  )\n}\n\nexport { CodeBlockGroup, CodeBlockCode, CodeBlock }\n",
+      "type": "registry:ui"
+    }
+  ]
+}

--- a/scripts/registry-build.ts
+++ b/scripts/registry-build.ts
@@ -17,6 +17,26 @@ if (!fs.existsSync(registryHooks)) {
 for (const component of components) {
   const content = fs.readFileSync(component.path, "utf8")
 
+  const files = [
+    {
+      path: `${component.name}.tsx`,
+      content,
+      type: "registry:ui" as const,
+    },
+  ]
+
+  // Add additional files if specified in the component definition
+  if (component.files && component.files.length > 0) {
+    for (const file of component.files) {
+      const fileContent = fs.readFileSync(file.path, "utf8")
+      files.push({
+        path: file.name,
+        content: fileContent,
+        type: "registry:ui" as const,
+      })
+    }
+  }
+
   const schema = {
     name: component.name,
     type: "registry:ui",
@@ -29,13 +49,7 @@ for (const component of components) {
       dark: {},
     },
     description: component.description,
-    files: [
-      {
-        path: `${component.name}.tsx`,
-        content,
-        type: "registry:ui",
-      },
-    ],
+    files,
   } satisfies Schema
 
   fs.writeFileSync(

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -14,6 +14,10 @@ type ComponentDefinition = Partial<
   name: string
   description: string
   path: string
+  files?: Array<{
+    name: string
+    path: string
+  }>
 }
 
 export const components: ComponentDefinition[] = [
@@ -23,5 +27,43 @@ export const components: ComponentDefinition[] = [
       "An input field designed for chat interfaces, allowing users to enter and submit text prompts to an AI model",
     path: path.join(__dirname, "../components/prompt-kit/prompt-input.tsx"),
     registryDependencies: ["textarea", "tooltip"],
+  },
+  {
+    name: "code-block",
+    description:
+      "A component for displaying code snippets with syntax highlighting and customizable styling",
+    path: path.join(__dirname, "../components/prompt-kit/code-block.tsx"),
+    dependencies: ["shiki"],
+  },
+  {
+    name: "markdown",
+    description:
+      "A component for rendering Markdown content with support for code blocks, GFM, and custom styling",
+    path: path.join(__dirname, "../components/prompt-kit/markdown.tsx"),
+    dependencies: ["react-markdown", "remark-gfm", "shiki"],
+    files: [
+      {
+        name: "code-block.tsx",
+        path: path.join(__dirname, "../components/prompt-kit/code-block.tsx"),
+      },
+    ],
+  },
+  {
+    name: "message",
+    description:
+      "A component for displaying chat messages with support for avatars, markdown content, and interactive actions",
+    path: path.join(__dirname, "../components/prompt-kit/message.tsx"),
+    dependencies: ["react-markdown", "remark-gfm", "shiki"],
+    registryDependencies: ["avatar", "tooltip"],
+    files: [
+      {
+        name: "markdown.tsx",
+        path: path.join(__dirname, "../components/prompt-kit/markdown.tsx"),
+      },
+      {
+        name: "code-block.tsx",
+        path: path.join(__dirname, "../components/prompt-kit/code-block.tsx"),
+      },
+    ],
   },
 ]


### PR DESCRIPTION
This PR introduces three new components:
- CodeBlock: For displaying code snippets with syntax highlighting using Shiki.
- Markdown: For rendering markdown content, supporting features like GFM and inline code blocks.
- Message: For displaying chat messages, including support for avatars and markdown content.
