### PR TITLE
link updated for 'get started' button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,7 +87,7 @@ export default function Home() {
           </p>
         </div>
         <Link
-          href="/docs"
+          href="/docs/introduction"
           className="inline-flex h-10 items-center justify-center rounded-full bg-black px-4 text-base text-white"
         >
           Get Started


### PR DESCRIPTION
`/docs` looks ambiguous as the sidebar is not highlighted and the pagination is hidden. Redirecting to `/docs/introduction` is a better approach.