### PR TITLE
fix: Unable to upload removed files when uploading

### DIFF
--- a/app/docs/prompt-input/prompt-input-with-actions.tsx
+++ b/app/docs/prompt-input/prompt-input-with-actions.tsx
@@ -8,12 +8,13 @@ import {
 } from "@/components/prompt-kit/prompt-input"
 import { Button } from "@/components/ui/button"
 import { ArrowUp, Paperclip, Square, X } from "lucide-react"
-import { useState } from "react"
+import { useRef, useState } from "react"
 
 export function PromptInputWithActions() {
   const [input, setInput] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [files, setFiles] = useState<File[]>([])
+  const uploadInputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = () => {
     if (input.trim() || files.length > 0) {
@@ -35,6 +36,9 @@ export function PromptInputWithActions() {
 
   const handleRemoveFile = (index: number) => {
     setFiles((prev) => prev.filter((_, i) => i !== index))
+    if (uploadInputRef?.current) {
+      uploadInputRef.current.value = ""
+    }
   }
 
   return (


### PR DESCRIPTION
In cases where file uploads are supported, previously uploaded files cannot be added again.
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8592f8d6-a2c0-4b37-894c-b44029d738ad" />
