### PR TITLE
fix: add remark-breaks dependency to markdown component

### DIFF
--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -53,7 +53,7 @@ export const components: ComponentDefinition[] = [
     description:
       "A component for displaying chat messages with support for avatars, markdown content, and interactive actions",
     path: path.join(__dirname, "../components/prompt-kit/message.tsx"),
-    dependencies: ["react-markdown", "remark-gfm", "shiki", "marked"],
+    dependencies: ["react-markdown", "remark-gfm", "shiki", "marked", "remark-breaks"],
     registryDependencies: ["avatar", "tooltip"],
     files: [
       {


### PR DESCRIPTION
Hey there, just a minor thing I stumbled upon while using the components. 
Keep up the great work! Thanks!