### PR TITLE
fix prompt-input textarea autosize

### DIFF
--- a/components/prompt-kit/prompt-input.tsx
+++ b/components/prompt-kit/prompt-input.tsx
@@ -114,7 +114,11 @@ function PromptInputTextarea({
     if (disableAutosize) return
 
     if (!textareaRef.current) return
-    textareaRef.current.style.height = "auto"
+
+    if (textareaRef.current.scrollTop === 0) {
+      textareaRef.current.style.height = "auto"
+    }
+
     textareaRef.current.style.height =
       typeof maxHeight === "number"
         ? `${Math.min(textareaRef.current.scrollHeight, maxHeight)}px`


### PR DESCRIPTION
When a scrollbar appears, after the Chinese input method input, textarea will always scroll to the top.

Bug video: When a scrollbar appears, the text will always scroll to the top after it is finally entered.

https://github.com/user-attachments/assets/8a20b757-a7c7-4915-b8fd-962b221ece77

Bug fixed:

https://github.com/user-attachments/assets/88a51f55-a112-4654-8bff-70935145cf79

