### PR TITLE
fix(examples): correct PromptInputBasic submit handler usage

### DIFF
--- a/app/docs/prompt-input/prompt-input-basic.tsx
+++ b/app/docs/prompt-input/prompt-input-basic.tsx
@@ -14,9 +14,9 @@ export function PromptInputBasic() {
   const [input, setInput] = useState("")
   const [isLoading, setIsLoading] = useState(false)
 
-  const handleSubmit = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.stopPropagation()
+  const handleSubmit = () => {
     setIsLoading(true)
+    // simulate request
     setTimeout(() => {
       setIsLoading(false)
     }, 2000)
@@ -31,7 +31,7 @@ export function PromptInputBasic() {
       value={input}
       onValueChange={handleValueChange}
       isLoading={isLoading}
-      onSubmit={() => handleSubmit}
+      onSubmit={handleSubmit}
       className="w-full max-w-(--breakpoint-md)"
     >
       <PromptInputTextarea placeholder="Ask me anything..." />
@@ -43,7 +43,7 @@ export function PromptInputBasic() {
             variant="default"
             size="icon"
             className="h-8 w-8 rounded-full"
-            onClick={() => handleSubmit}
+            onClick={handleSubmit}
           >
             {isLoading ? (
               <Square className="size-5 fill-current" />


### PR DESCRIPTION
This PR fixes the `PromptInputBasic` example which currently shows incorrect submit handler usage.

### Problem
- `handleSubmit` had the wrong signature: `(event: React.ChangeEvent<HTMLInputElement>)`.
- `onSubmit={() => handleSubmit}` returned a function reference instead of calling `handleSubmit`.
- Same issue for the `<Button onClick>`.
- As a result, the example never actually triggered `handleSubmit` and `isLoading` did not toggle.

### Changes
- Updated `handleSubmit` to `const handleSubmit = () => { ... }`.
- Passed `onSubmit={handleSubmit}` to `<PromptInput>`.
- Passed `onClick={handleSubmit}` to `<Button>`.

### Before
```tsx
<PromptInput
  ...
  onSubmit={() => handleSubmit}
/>

<Button onClick={() => handleSubmit}>...</Button>
````

### After

```tsx
<PromptInput
  ...
  onSubmit={handleSubmit}
/>

<Button onClick={handleSubmit}>...</Button>
```

### Related Issue

Closes #83 
