### PR TITLE
fix(source): fix text-leading for labels and add tabular-nums for consistent width of number based labels

### DIFF
--- a/components/prompt-kit/source.tsx
+++ b/components/prompt-kit/source.tsx
@@ -62,7 +62,7 @@ export function SourceTrigger({
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
-          "bg-muted text-muted-foreground hover:bg-muted-foreground/30 hover:text-primary inline-flex h-5 max-w-32 items-center gap-1 overflow-hidden rounded-full py-0 text-xs leading-none no-underline transition-colors duration-150",
+          "bg-muted text-muted-foreground hover:bg-muted-foreground/30 hover:text-primary inline-flex h-5 max-w-32 items-center gap-1 overflow-hidden rounded-full py-0 text-xs no-underline transition-colors duration-150",
           showFavicon ? "pr-2 pl-1" : "px-1",
           className
         )}
@@ -78,7 +78,7 @@ export function SourceTrigger({
             className="size-3.5 rounded-full"
           />
         )}
-        <span className="truncate text-center font-normal">{labelToShow}</span>
+        <span className="truncate tabular-nums text-center font-normal">{labelToShow}</span>
       </a>
     </HoverCardTrigger>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "prompt-kit",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.2",
         "@ai-sdk/react": "^2.0.0-beta.33",


### PR DESCRIPTION
### Before

In the source UI component:

- the leading of label texts are getting cropped currently so  i removed "leading-none" styling 

- there's a inconsistent width among number based label due to missing of "tabular-nums" styling, so i added that.

<img width="988" height="534" alt="image" src="https://github.com/user-attachments/assets/5c415eb7-4f2a-4ac2-b589-e18a850f8617" />

<img width="988" height="534" alt="image" src="https://github.com/user-attachments/assets/19f26c2a-9026-4883-af84-5ca110665149" />

### After

<img width="988" height="534" alt="image" src="https://github.com/user-attachments/assets/7e8d104d-87a6-406d-8a72-93f78b909a15" />

<img width="988" height="534" alt="image" src="https://github.com/user-attachments/assets/3fc2aeb1-38cb-40e6-a9da-26595d773a7c" />

